### PR TITLE
Fixed crash when new number of cells is less than previous number of cells after when doing a reloadData.

### DIFF
--- a/TMQuiltView/TMQuiltView/TMQuiltView.m
+++ b/TMQuiltView/TMQuiltView/TMQuiltView.m
@@ -300,6 +300,8 @@ NSString *const kDefaultReusableIdentifier = @"kTMQuiltViewDefaultReusableIdenti
     
     _numberOfColumms = [self numberOfColumns];
     
+	[self.indexPaths removeAllObjects];
+	
     NSInteger numberOfRows = [self numberOfCells];
     for(NSInteger i = 0; i < numberOfRows; i++) {
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:i inSection:0];


### PR DESCRIPTION
Fixed crash when new number of cells is less than previous number of cells after when doing a reloadData.
