### PR TITLE
Cells not reloading after NSFetchedResultsController-backed model changes

### DIFF
--- a/TMQuiltView/TMQuiltView/TMQuiltView.m
+++ b/TMQuiltView/TMQuiltView/TMQuiltView.m
@@ -300,6 +300,7 @@ NSString *const kDefaultReusableIdentifier = @"kTMQuiltViewDefaultReusableIdenti
     _numberOfColumms = [self numberOfColumns];
     
     [self regenerateIndexPaths];
+    [self setNeedsLayout];
     [self resetView];
 }
 


### PR DESCRIPTION
This is in response to issue #2. The problem is that `layoutSubviews` is never called.
