### PR TITLE
leave one cell in quiltView

### DIFF
--- a/TMQuiltView/TMQuiltView/TMQuiltView.m
+++ b/TMQuiltView/TMQuiltView/TMQuiltView.m
@@ -466,7 +466,9 @@ NSString *const kDefaultReusableIdentifier = @"kTMQuiltViewDefaultReusableIdenti
         // Harvest any any views that have moved off screen and add them to the reuse pool
         for (NSIndexPath* indexPath in [indexPathToView allKeys]) {
             TMQuiltViewCell *view = [indexPathToView objectForKey:indexPath];
-            if (![TMQuiltView isRect:view.frame partiallyInScrollView:self]) { // Rect intersection?
+            // the indexPathToView must has one indexPath，we should not remove all cell in quiltView,
+            // if *top == *bottom ,there is one cell in quitView ,so at this time,cell can not be removed
+            if (![TMQuiltView isRect:view.frame partiallyInScrollView:self] && indexPathToView.count > 1) { // Rect intersection?
                 [indexPathToView removeObjectForKey:indexPath];
                 // Limit the size on the reuse pool
                 if ([[self reusableViewsWithReuseIdentifier:view.reuseIdentifier] count] < 10) {


### PR DESCRIPTION
sometimes ,there is only one cell in quiltView ,at this time,*top == *bottom,if we remove the only cell ,then we can not see any cell.
I often use class with "top view" or "bottom view", yeah! for example ,I set the margin top  300dp,and I add a TopView in the quiltView ,the TopView like the head of UITableView, but When I drag it down until the first cell disappear in quiltView ,I loosen. I am so puzzled that I can only see the TopView , the cell disappear,but when I swipe the quiltView fastly ,sometimes all cells has appear.Although like this，I think the quiltView still has one flaw，so I restore it .
