### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can also directly open the TMQuiltViewDemo in XCode and build the project.
     [super dealloc];
 }
 
-#pragma mark - UIViewController
+# pragma mark - UIViewController
 
 - (void)viewDidLoad
 {
@@ -62,7 +62,7 @@ You can also directly open the TMQuiltViewDemo in XCode and build the project.
     }
 }
 
-#pragma mark - QuiltViewControllerDataSource
+# pragma mark - QuiltViewControllerDataSource
 
 - (NSArray *)images {
     if (!_images) {
@@ -94,7 +94,7 @@ You can also directly open the TMQuiltViewDemo in XCode and build the project.
     return cell;
 }
 
-#pragma mark - TMQuiltViewDelegate
+# pragma mark - TMQuiltViewDelegate
 
 - (NSInteger)quiltViewNumberOfColumns:(TMQuiltView *)quiltView {
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
